### PR TITLE
feat!: Add webTheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "ts-deepmerge": "^1.0.8"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import NextApp from 'next/app';
-import theme from '../src/theme';
+import { theme } from '../src/theme';
 import { ThemeProvider } from 'theme-ui';
 
 export default class App extends NextApp {

--- a/pages/web.tsx
+++ b/pages/web.tsx
@@ -20,20 +20,22 @@ import {
 } from '@theme-ui/components';
 import { BaseStyles, ThemeProvider } from 'theme-ui';
 import Head from 'next/head';
-import { theme } from '../src';
+import { webTheme } from '../src';
 import { TypeScale, ColorPalette } from '@theme-ui/style-guide';
 import { HiArrowRight } from 'react-icons/hi';
 
-const DocsPage = () => (
+const theme = webTheme;
+
+const WebThemePage = () => (
   <ThemeProvider theme={theme}>
     <Container sx={{ bg: 'muted' }}>
       <Head>
-        <title>Indiv Theme</title>
+        <title>Indiv Web Theme</title>
       </Head>
       <Box as="header" sx={{ color: 'text' }}>
         <Container sx={{ pt: 5, pb: [3, 4] }}>
           <Heading as="h1" variant="title" color="primary">
-            Indiv Theme
+            Indiv Web Theme
           </Heading>
           <Grid
             gap={4}
@@ -50,7 +52,9 @@ const DocsPage = () => (
             <NavLink href="https://npmjs.com/package/@indivno/theme">
               NPM
             </NavLink>
-            <NavLink href="/web">Web Theme</NavLink>
+            <NavLink href="/">
+              Base Theme
+            </NavLink>
           </Grid>
         </Container>
       </Box>
@@ -194,4 +198,4 @@ const DocsPage = () => (
   </ThemeProvider>
 );
 
-export default DocsPage;
+export default WebThemePage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { webTheme } from './web/theme';
+export { theme } from './theme';

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,6 +3,8 @@ import { buttons } from './button';
 import { layout } from './layout';
 import { styles } from './styles';
 
+export { webTheme } from './web/theme';
+
 export const theme = {
   sizes: {
     container: 1205,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,8 +3,6 @@ import { buttons } from './button';
 import { layout } from './layout';
 import { styles } from './styles';
 
-export { webTheme } from './web/theme';
-
 export const theme = {
   sizes: {
     container: 1205,
@@ -115,5 +113,3 @@ export const theme = {
   layout,
   buttons,
 };
-
-export default theme;

--- a/src/web/theme.ts
+++ b/src/web/theme.ts
@@ -1,4 +1,4 @@
-import merge from 'ts-deepmerge';
+import merge from 'ts-deepmerge';
 import { theme } from '../theme';
 
 export const webTheme = merge(theme, {

--- a/src/web/theme.ts
+++ b/src/web/theme.ts
@@ -1,0 +1,12 @@
+import merge from 'ts-deepmerge';
+import { theme } from '../theme';
+
+export const webTheme = merge(theme, {
+  buttons: {
+    primary: {
+      '&:focus': {
+        borderColor: 'secondary',
+      },
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3048,6 +3048,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-deepmerge@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/ts-deepmerge/-/ts-deepmerge-1.0.8.tgz#927ebb0db106bdc4a15011c288a2024496638900"
+  integrity sha512-d3ZRKksHOOUQpLpB8qncIrcbRKGO/TWIC8hncD0QkEMAxTPq39hqRig0LM4fHnuZW3tWID/aNxjbAFW50IV3Lw==
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"


### PR DESCRIPTION
Adds an endpoint for the web theme: https://deploy-preview-18--indiv-theme.netlify.app/web

BREAKING CHANGE: Removed default export. `import theme from '@indivorg/theme'` changes to `import { theme } from '@indivorg/theme'`.

Trying to honour the `import/no-default-export` rule. 👆

fixes #17 