### PR TITLE
feat: add overflow-y to prevent scrollbar issue

### DIFF
--- a/src/web/theme.ts
+++ b/src/web/theme.ts
@@ -13,6 +13,7 @@ export const webTheme = merge(theme, {
     root: {
       WebkitFontSmoothing: 'antialiased',
       MozOsxFontSmoothing: 'grayscale',
+      overflowY: 'scroll',
     },
   },
 });


### PR DESCRIPTION
This should prevent the scrollbar appearing from pushing the entire site horizontally (visible jump between pages with/without scrollbar)

fixes #41 