### PR TITLE
feat: implement new badge style

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -109,8 +109,9 @@ export const theme: IndivTheme = {
       borderRadius: 4,
       py: 1,
       px: 2,
-      bg: 'primary',
-      color: 'background',
+      bg: 'lightGreen',
+      color: 'text',
+      fontWeight: 'body',
     },
     secondary: {
       border: '3px solid',
@@ -120,6 +121,7 @@ export const theme: IndivTheme = {
       px: 2,
       bg: 'background',
       color: 'primary',
+      fontWeight: 'body',
     },
   },
   images: {


### PR DESCRIPTION
Matches new design for the primary badge. Unsure if we want to change the secondary style? Do we want to keep it?

The secondary style is used on the `SingleUser` page for the role badges.

One thing I noticed is that the font looks a bit thinner than on Figma even though the weight is the same. Or maybe I'm just imagining it.

**In the app:**

![Screenshot 2021-11-25 at 11 30 01](https://user-images.githubusercontent.com/5765650/143415627-015ba326-28a8-47be-a428-79ba1bd64cde.png)

**In figma:**
<img width="244" alt="Screenshot 2021-11-25 at 11 30 41" src="https://user-images.githubusercontent.com/5765650/143415719-3fed8322-608c-4f93-8201-37f98b97d48c.png">

