### PR TITLE
feat: implement new divider style

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Checkbox,
   Container,
+  Divider,
   Flex,
   Grid,
   Heading,
@@ -109,6 +110,7 @@ const Sheet: React.FC<{ theme: IndivTheme; name: string }> = ({
                 <code>Here’s a code block! No highlighting to be found.</code>
               </pre>
             </Card>
+            <Divider />
             <Heading>Buttons</Heading>
             <Card>
               <Flex sx={{ flexWrap: 'wrap' }}>
@@ -158,6 +160,7 @@ const Sheet: React.FC<{ theme: IndivTheme; name: string }> = ({
                     </Card>
                   ))}
                 </Grid> */}
+            <Divider />
             <Heading>Forms</Heading>
             <Grid gap={3} columns={[null, 2]} as="form" variant="cards.sunken">
               <Label>
@@ -207,6 +210,8 @@ const Sheet: React.FC<{ theme: IndivTheme; name: string }> = ({
                 sx={{ gridColumn: [null, 'span 2'] }}
               />
             </Grid>
+
+            <Divider />
             <Heading>Badges</Heading>
             {Object.keys(theme.badges).map(key => (
               <Badge
@@ -218,6 +223,7 @@ const Sheet: React.FC<{ theme: IndivTheme; name: string }> = ({
                 {key}
               </Badge>
             ))}
+            <Divider />
             <Heading>Colors</Heading>
             <ColorPalette
               omit={[
@@ -229,6 +235,7 @@ const Sheet: React.FC<{ theme: IndivTheme; name: string }> = ({
               ]}
             />
             <TypeScale />
+            <Divider />
             <Text as="pre" variant="styles.pre">
               {JSON.stringify(theme, null, 2)}
             </Text>

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -58,7 +58,7 @@ export const styles: Theme['styles'] = {
   hr: {
     my: 4,
     border: '1px solid',
-    boxShadow: '0px 4px 4px rgba(0,0,0,0.25)',
-    color: 'muted',
+    borderWidth: '1px',
+    color: 'lightGreen',
   },
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -57,7 +57,7 @@ export const styles: Theme['styles'] = {
   },
   hr: {
     my: 4,
-    border: 'solid',
+    borderStyle: 'solid',
     borderWidth: 2,
     color: 'lightGreen',
   },

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -57,7 +57,7 @@ export const styles: Theme['styles'] = {
   },
   hr: {
     my: 4,
-    border: 'olid',
+    border: 'solid',
     borderWidth: 2,
     color: 'lightGreen',
   },

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -57,8 +57,8 @@ export const styles: Theme['styles'] = {
   },
   hr: {
     my: 4,
-    borderWidth: 2,
-    borderStyle: 'dashed',
-    color: 'primary',
+    border: '1px solid',
+    boxShadow: '0px 4px 4px rgba(0,0,0,0.25)',
+    color: 'muted',
   },
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -57,8 +57,8 @@ export const styles: Theme['styles'] = {
   },
   hr: {
     my: 4,
-    border: '1px solid',
-    borderWidth: '1px',
+    border: 'olid',
+    borderWidth: 2,
     color: 'lightGreen',
   },
 };


### PR DESCRIPTION
Really not sure about this one. px values galore

The current style with dashed lines is egregious:
![Screenshot 2021-11-25 at 13 34 19](https://user-images.githubusercontent.com/5765650/143434452-2393a9cc-dfb2-4279-8dae-63e9df194148.png)

I copied attributes from the design files and ended up with this, which doesn't look right either:
![Screenshot 2021-11-25 at 13 35 40](https://user-images.githubusercontent.com/5765650/143434627-c302902e-b62f-4412-9122-4849a17f87f1.png)


