### PR TITLE
refactor!: Remove unstyled button

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -102,4 +102,7 @@ export const buttons: Theme['buttons'] = {
       cursor: 'default',
     },
   },
+  icon: {
+    mouse: 'cursor',
+  },
 };

--- a/src/button.ts
+++ b/src/button.ts
@@ -103,6 +103,6 @@ export const buttons: Theme['buttons'] = {
     },
   },
   icon: {
-    mouse: 'cursor',
+    cursor: 'pointer',
   },
 };

--- a/src/button.ts
+++ b/src/button.ts
@@ -102,18 +102,4 @@ export const buttons: Theme['buttons'] = {
       cursor: 'default',
     },
   },
-  unstyled: {
-    background: 'none',
-    textDecoration: 'none',
-    color: 'inherit',
-    display: 'flex',
-    alignItems: 'center',
-    cursor: 'pointer',
-    px: 0,
-    py: 0,
-    m: 0,
-    mr: 0,
-    gap: 2,
-    fontSize: 5,
-  },
 };


### PR DESCRIPTION
According to #45 we're using button to compose other components, and to ease that implementation we're using this unstyled variant.

IMHO, this isn't what variants should be used for. It's much better to have a ordinary Javascript object which has the values to reset a button than using the variant concept to solve this. My reasoning is that an unstyled button is not a variant of a button. Essentially, a button variant is typically `primary`, `outlined` which have two use-cases in a design.
